### PR TITLE
refactor rendering

### DIFF
--- a/src/gb.lisp
+++ b/src/gb.lisp
@@ -62,7 +62,7 @@
           ))
           (#x60
            (case (logand addr #x000f)
-             ((#x8 #x9 #xa #xb) (ppu-write-memory-at-addr (gb-ppu gb) addr val))
+             ((#x8 #x9 #xa #xb) (ppu-write-memory-at-addr (gb-ppu gb) addr val)) ; CGB PPU palletes
              (otherwise (setf (aref (gb-zero-page gb) (logand addr #xff)) val))))
           (#x70
            (case (logand addr #x000f)


### PR DESCRIPTION
* refactor background, window, and sprite rendering to generate scanlines
* deferred priority and transparency calculations for displaying pixels until all scanlines exist
* limit framebuffer writes to single function
* scanline functions no longer take the whole ppu state